### PR TITLE
Finished integration of sync-service in compose file

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -25,6 +25,8 @@ services:
       - DJANGO_SUPERUSER_USERNAME=stayhome
       - DJANGO_SUPERUSER_EMAIL=dev@stayhome.ch
       - DJANGO_SUPERUSER_PASSWORD=stayhome
+      - SYNC_USER=sync
+      - SYNC_PASSWORD=sync
       - RECAPTCHA_PUBLIC_KEY=""
       - RECAPTCHA_PRIVATE_KEY=""
       - DJANGO_SECRET_KEY=verynotsecretkey
@@ -35,19 +37,21 @@ services:
       - db
     restart: always
     volumes:
-      - ./stayhome/:/code/
+      - api_key:/api
 
   sync-service:
     build: sync-service/
     container_name: sync-service
     environment:
       - STAYHOME_API_URL=http://web:8000/api
-      - STAYHOME_API_TOKEN=${STAYHOME_API_TOKEN}
     ports:
       - 127.0.0.1:8080:8080
     depends_on:
       - web
     restart: always
+    volumes:
+      - api_key:/api
 
 volumes:
   db_data:
+  api_key:

--- a/stayhome/Dockerfile
+++ b/stayhome/Dockerfile
@@ -13,4 +13,6 @@ RUN pip install -r requirements.txt
 
 RUN apk del build-base
 
+COPY . .
+
 CMD [ "./wait-for-it.sh" , "-h", "db", "-p", "3306" , "--strict" , "--timeout=300" , "--", "./start.sh" ]

--- a/stayhome/create_api_key.py
+++ b/stayhome/create_api_key.py
@@ -1,0 +1,45 @@
+import os
+import django
+
+from stayhome.wsgi import set_environment
+
+# Set environment and setup Django
+set_environment()
+django.setup()
+
+from django.contrib.auth.models import User
+from rest_framework.authtoken.models import Token
+
+def main():
+
+    # Get required variables from environment
+    username = os.environ.get("SYNC_USER", default='sync')
+    password = os.environ.get("SYNC_PASSWORD", default='sync')
+
+    # Echo
+    print('Creating API user %s and generating API token...' % username)
+
+    # Create user if it does not exist already
+    try:
+        user = User.objects.get(username=username)
+    except User.DoesNotExist:
+        user = User.objects.create_user(username, password=password)
+        user.save()
+
+    # Create API key if it does not exist already
+    try:
+        token = Token.objects.get(user=user)
+    except Token.DoesNotExist:
+        token = Token.objects.create(user=user)
+
+    # Key file
+    key_file_path = '/api/key.txt'
+    if os.environ.get("RUNNING_ENV", default='dev-nodb') == 'dev-nodb':
+        key_file_path = '/tmp/api_key.txt'
+
+    # Store key to file
+    with open(key_file_path, 'w+') as key_file:
+        key_file.write(token.key)
+
+if __name__ == '__main__':
+    main()

--- a/stayhome/start.sh
+++ b/stayhome/start.sh
@@ -9,12 +9,11 @@ python manage.py createsuperuser --no-input
 # Import data, only with new repo
 # Do it manually in container later if necessary
 # This is to avoid a very long startup delay
-if [ -f "datasets/post_data.csv.bz2" ]; then
+if [ ! -f "datasets/.imported" ]; then
 
     # Uncompress Swiss Post dataset
     cd datasets
-    bunzip2 post_data.csv.bz2
-    mv post_data.csv.bz2 post_data.csv.bz2.imported
+    bunzip2 -f post_data.csv.bz2
     cd ..
 
     # Import Swiss Post dataset - Creates municipalities and postal codes (NPA)
@@ -29,6 +28,9 @@ if [ -f "datasets/post_data.csv.bz2" ]; then
     # Attach municipalities to districts
     python manage.py geo_import_municipalities datasets/municipalities.csv
 
+    # Not importing anymore
+    touch datasets/.imported
+
 fi
 
 # Compile language files
@@ -39,6 +41,9 @@ python manage.py collectstatic --noinput
 
 # Translations
 python manage.py update_translation_fields
+
+# Generate API key for sync-service
+python create_api_key.py
 
 # Run application
 gunicorn -b 0.0.0.0:8000 stayhome.wsgi

--- a/stayhome/stayhome/wsgi.py
+++ b/stayhome/stayhome/wsgi.py
@@ -15,7 +15,6 @@ from django.core.wsgi import get_wsgi_application
 # Utility variable to detect environment to use
 def set_environment():
 
-
     # Choosing environment
     RUNNING_ENV = os.environ.get("RUNNING_ENV", default='dev-nodb')
     print('******************************************************************************')


### PR DESCRIPTION
Implemented a way to have it running all together nicely.

At startup, the web app will create a user (if not already existing), username coming from env variable SYNC_USER and password from SYNC_PASSWORD. Then, it will generate a Token for this user (if not already existing).

In order to pass the token key to the sync-service app, a shared volume is created between the two containers. At startup, the web app will write the key to /api/key.txt and the sync-service must read the key at the same path and use it.

Note that this happens before the web app http server is started. If you need the API key at startup in the sync-service, you should ensure that you are not reading the key before the http service on port 8000 is available on the web container. This can be done using the wait-for-it.sh script that is also used by the web app to wait for the database.

This PR also improve the startup script for the web app with a more predictable behavior on the handling of datasets imports.